### PR TITLE
Rename input_components to input_widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ class SimpleFormModel(BaseModel):
 
 
 with st_auto_form("form_1", model=SimpleFormModel) as simple_form:
-    val = simple_form.input_components()
+    val = simple_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write("slider", val.slider_val, "checkbox", val.checkbox_val)
@@ -69,7 +69,7 @@ class ParentFormModel(BaseModel):
     child: ChildFormModel
 
 with st_auto_form("form_2", model=ParentFormModel) as parent_form:
-    val2 = parent_form.input_components()
+    val2 = parent_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write(
@@ -111,7 +111,7 @@ class PointFormModel(BaseModel):
     p: Annotated[PointModel, PointWidget()]
 
 with st_auto_form("form_3", model=PointFormModel) as point_form:
-    val3 = point_form.input_components()
+    val3 = point_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write("p", val3.p)

--- a/example_app.py
+++ b/example_app.py
@@ -14,7 +14,7 @@ class SimpleFormModel(BaseModel):
 
 
 with st_auto_form("form_1", model=SimpleFormModel) as simple_form:
-    val = simple_form.input_components()
+    val = simple_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write("slider", val.slider_val, "checkbox", val.checkbox_val)
@@ -34,7 +34,7 @@ class ParentFormModel(BaseModel):
 
 
 with st_auto_form("form_2", model=ParentFormModel) as parent_form:
-    val2 = parent_form.input_components()
+    val2 = parent_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write(
@@ -69,7 +69,7 @@ class PointFormModel(BaseModel):
 
 
 with st_auto_form("form_3", model=PointFormModel) as point_form:
-    val3 = point_form.input_components()
+    val3 = point_form.input_widgets()
     submitted = st.form_submit_button("Submit")
     if submitted:
         st.write("p", val3.p)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1430,4 +1430,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11"
-content-hash = "2ffe170bc28fabbdf17b3d85ed00e4d746939a92e500e46de28794a1d3183986"
+content-hash = "008a4d71482f1e149cfc50c63150ea39927d2c11fba4befb3b70fbe80dc8b68e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = ">=3.11"
 streamlit = ">=1.11.0"
 pydantic = ">=2.5.3"
+typing-extensions = ">=4.9.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.1.13"

--- a/streamlit_pydantic_form/form.py
+++ b/streamlit_pydantic_form/form.py
@@ -24,7 +24,7 @@ class st_auto_form(Generic[_T]):  # noqa: N801
         self.border = border
         self.form = st.form(key=self.key, clear_on_submit=self.clear_on_submit)
 
-    def input_components(self) -> _T:
+    def input_widgets(self) -> _T:
         return _model_to_input_components(self.model)
 
     def __enter__(self) -> Self:

--- a/streamlit_pydantic_form/form.py
+++ b/streamlit_pydantic_form/form.py
@@ -1,8 +1,10 @@
+import warnings
 from types import TracebackType
 from typing import Any, Generic, Self, TypeVar
 
 import streamlit as st
 from pydantic import BaseModel
+from typing_extensions import deprecated
 
 from .widget import WidgetBuilder
 
@@ -26,6 +28,17 @@ class st_auto_form(Generic[_T]):  # noqa: N801
 
     def input_widgets(self) -> _T:
         return _model_to_input_components(self.model)
+
+    @deprecated(
+        "st_auto_form.input_components() is deprecated, use st_auto_form.input_widgets() instead",
+    )
+    def input_components(self) -> _T:
+        warnings.warn(
+            "st_auto_form.input_components() is deprecated, use st_auto_form.input_widgets() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.input_widgets()
 
     def __enter__(self) -> Self:
         # Enter the inner st.form


### PR DESCRIPTION
- Update input_components to input_widgets in form.py
- Add typing-extensions dependency
- Add deprecated warning for input_components() method
- Update content-hash in poetry.lock
