### PR TITLE
chore: ignore Ruff CPY001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ ignore = [
   "TD003",  # add link on issue into TODO
   "FIX002",  # Line contains TODO
   "ERA001",  # commented-out-code
+  "CPY001",  # missing copyright notice
   "PLR0913",  # Too many arguments in function definition
 ]
 


### PR DESCRIPTION
Configure Ruff to ignore the CPY001 copyright-notice rule.